### PR TITLE
Centralize workspace dependencies and update rand/criterion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,6 +692,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +861,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,10 +880,11 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
@@ -863,6 +893,7 @@ dependencies = [
  "itertools",
  "num-traits",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
@@ -874,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.6.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -1430,6 +1461,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core",
  "wasip2",
  "wasip3",
 ]
@@ -2481,6 +2513,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2718,15 +2760,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2820,32 +2853,20 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.2",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "range-alloc"
@@ -4090,6 +4111,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4097,6 +4134,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,19 @@
 resolver = "2"
 members = ["amaze", "amaze-cli", "amaze-gui"]
 default-members = ["amaze-cli", "amaze-gui"]
+
+[workspace.dependencies]
+# Internal dependencies
+amaze = { path = "amaze" }
+
+# Direct dependencies
+rand = "^0.10.1"
+serde = { version = "1", features = ["derive"] }
+petgraph = "0.8"
+clap = "4.6.0"
+eframe = "0.34.1"
+egui = "0.34.1"
+
+# Dev dependencies
+indoc = "2.0.7"
+criterion = "0.8"

--- a/amaze-cli/Cargo.toml
+++ b/amaze-cli/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2024"
 rust-version = "1.85.0"
 
 [dependencies]
-amaze = { path = "../amaze", features = ["renderers"] }
-clap = "4.6.0"
+amaze = { workspace = true, features = ["renderers"] }
+clap.workspace = true

--- a/amaze-gui/Cargo.toml
+++ b/amaze-gui/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2024"
 rust-version = "1.92.0"
 
 [dependencies]
-amaze = { path = "../amaze" }
-eframe = "0.34.1"
-egui = "0.34.1"
+amaze.workspace = true
+eframe.workspace = true
+egui.workspace = true

--- a/amaze/Cargo.toml
+++ b/amaze/Cargo.toml
@@ -46,13 +46,13 @@ petgraph = ["dep:petgraph", "representations"]
 serde = ["dep:serde"]
 
 [dependencies]
-rand = "^0.9.3"
-serde = { version = "1", features = ["derive"], optional = true }
-petgraph = { version = "0.8", optional = true }
+rand.workspace = true
+serde = { workspace = true, optional = true }
+petgraph = { workspace = true, optional = true }
 
 [dev-dependencies]
-indoc = "2.0.7"
-criterion = "0.7"
+indoc.workspace = true
+criterion.workspace = true
 
 [[bench]]
 name = "generation"

--- a/amaze/src/dungeon/generators.rs
+++ b/amaze/src/dungeon/generators.rs
@@ -2,7 +2,7 @@ use crate::dungeon::{DungeonGrid, DungeonType, TileType};
 use crate::grid_coord_2d::{GetCoordinateBounds2D, GridCoord2D};
 use rand::prelude::IndexedRandom;
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 
 /// Generation step for dungeon creation (for animation support).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -125,7 +125,7 @@ pub trait DungeonGenerator {
 /// - Rooms: Long corridors with stamped rectangular rooms
 /// - Winding: Like Rooms, but with probabilistic room suppression
 pub struct DungeonWalkGenerator {
-    rng: StdRng,
+    rng_seed: u64,
     dungeon_type: DungeonType,
     /// Winding hall probability (0-99). Only used for Winding type.
     /// Probability of creating a room is (99 - winding_hall_probability) / 100.
@@ -152,7 +152,7 @@ impl DungeonWalkGenerator {
     /// Create a new generator of the specified type with a random seed.
     pub fn new_random(dungeon_type: DungeonType) -> Self {
         Self {
-            rng: StdRng::from_os_rng(),
+            rng_seed: rand::random(),
             dungeon_type,
             winding_hall_probability: 50, // Default Unity value
             long_walk_min: 9,             // Default Unity value
@@ -162,14 +162,10 @@ impl DungeonWalkGenerator {
 
     /// Create a new generator with a specific seed.
     pub fn new_from_seed(dungeon_type: DungeonType, seed: u64) -> Self {
-        let rng = if seed == 0 {
-            StdRng::from_os_rng()
-        } else {
-            StdRng::seed_from_u64(seed)
-        };
+        let rng_seed = if seed == 0 { rand::random() } else { seed };
 
         Self {
-            rng,
+            rng_seed,
             dungeon_type,
             winding_hall_probability: 50,
             long_walk_min: 9,
@@ -225,7 +221,7 @@ impl DungeonWalkGenerator {
         emit_wall_steps: bool,
     ) -> DungeonGrid {
         let mut grid = DungeonGrid::new(width, height);
-        let mut rng = self.rng.clone();
+        let mut rng = StdRng::seed_from_u64(self.rng_seed);
 
         if width == 0 || height == 0 || floor_count == 0 {
             visitor.on_step(&DungeonGenerationStep::Complete);

--- a/amaze/src/generators/binary_tree4.rs
+++ b/amaze/src/generators/binary_tree4.rs
@@ -4,10 +4,10 @@ use crate::generators::{
 use crate::grid_coord_2d::GridCoord2D;
 use crate::wall4_grid::Wall4Grid;
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 
 pub struct BinaryTree4 {
-    rng: StdRng,
+    rng_seed: u64,
 }
 
 impl Default for BinaryTree4 {
@@ -25,7 +25,7 @@ impl BinaryTree4 {
             return (grid, visitor.into_steps());
         }
 
-        let mut rng = self.rng.clone();
+        let mut rng = StdRng::seed_from_u64(self.rng_seed);
         for y in 0..height {
             for x in 0..width {
                 let cell = GridCoord2D::new(x, y);
@@ -64,7 +64,7 @@ impl BinaryTree4 {
 impl MazeGenerator2D for BinaryTree4 {
     fn new_random() -> Self {
         Self {
-            rng: StdRng::from_os_rng(),
+            rng_seed: rand::random(),
         }
     }
 
@@ -72,9 +72,7 @@ impl MazeGenerator2D for BinaryTree4 {
         if rng_seed == 0 {
             Self::new_random()
         } else {
-            Self {
-                rng: StdRng::seed_from_u64(rng_seed),
-            }
+            Self { rng_seed }
         }
     }
 

--- a/amaze/src/generators/cell_selector.rs
+++ b/amaze/src/generators/cell_selector.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 pub trait CellSelector {
     fn select<R: Rng>(&self, rng: &mut R, frontier_len: usize) -> usize;

--- a/amaze/src/generators/eller4.rs
+++ b/amaze/src/generators/eller4.rs
@@ -4,11 +4,11 @@ use crate::generators::{
 use crate::grid_coord_2d::GridCoord2D;
 use crate::wall4_grid::Wall4Grid;
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 use std::collections::HashMap;
 
 pub struct Eller4 {
-    rng: StdRng,
+    rng_seed: u64,
 }
 
 impl Default for Eller4 {
@@ -30,7 +30,7 @@ impl Eller4 {
             visitor.on_step(&GenerationStep::Visit { cell });
         }
 
-        let mut rng = self.rng.clone();
+        let mut rng = StdRng::seed_from_u64(self.rng_seed);
         let mut set_ids: Vec<usize> = (0..width).collect();
         let mut next_set_id = width;
 
@@ -97,7 +97,7 @@ impl Eller4 {
 impl MazeGenerator2D for Eller4 {
     fn new_random() -> Self {
         Self {
-            rng: StdRng::from_os_rng(),
+            rng_seed: rand::random(),
         }
     }
 
@@ -105,9 +105,7 @@ impl MazeGenerator2D for Eller4 {
         if rng_seed == 0 {
             Self::new_random()
         } else {
-            Self {
-                rng: StdRng::seed_from_u64(rng_seed),
-            }
+            Self { rng_seed }
         }
     }
 

--- a/amaze/src/generators/growing_tree4.rs
+++ b/amaze/src/generators/growing_tree4.rs
@@ -7,10 +7,10 @@ use crate::visit_map_2d::VisitMap2D;
 use crate::wall4_grid::Wall4Grid;
 use rand::prelude::SliceRandom;
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 
 pub struct GrowingTree4<S: CellSelector = NewestCell> {
-    rng: StdRng,
+    rng_seed: u64,
     selector: S,
 }
 
@@ -20,19 +20,19 @@ where
 {
     pub fn with_selector(selector: S) -> Self {
         Self {
-            rng: StdRng::from_os_rng(),
+            rng_seed: rand::random(),
             selector,
         }
     }
 
     pub fn new_from_seed_with_selector(rng_seed: u64, selector: S) -> Self {
-        let rng = if rng_seed == 0 {
-            StdRng::from_os_rng()
+        let rng_seed = if rng_seed == 0 {
+            rand::random()
         } else {
-            StdRng::seed_from_u64(rng_seed)
+            rng_seed
         };
 
-        Self { rng, selector }
+        Self { rng_seed, selector }
     }
 
     fn generate_with_steps(&self, width: usize, height: usize) -> (Wall4Grid, Vec<GenerationStep>) {
@@ -46,7 +46,7 @@ where
             return (grid, visitor.into_steps());
         }
 
-        let mut rng = self.rng.clone();
+        let mut rng = StdRng::seed_from_u64(self.rng_seed);
         let start = GridCoord2D::new(rng.random_range(0..width), rng.random_range(0..height));
 
         visited[start] = true;
@@ -89,7 +89,7 @@ where
 {
     fn new_random() -> Self {
         Self {
-            rng: StdRng::from_os_rng(),
+            rng_seed: rand::random(),
             selector: S::default(),
         }
     }
@@ -99,7 +99,7 @@ where
             Self::new_random()
         } else {
             Self {
-                rng: StdRng::seed_from_u64(rng_seed),
+                rng_seed,
                 selector: S::default(),
             }
         }

--- a/amaze/src/generators/hunt_and_kill4.rs
+++ b/amaze/src/generators/hunt_and_kill4.rs
@@ -6,10 +6,10 @@ use crate::visit_map_2d::VisitMap2D;
 use crate::wall4_grid::Wall4Grid;
 use rand::prelude::SliceRandom;
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 
 pub struct HuntAndKill4 {
-    rng: StdRng,
+    rng_seed: u64,
 }
 
 impl Default for HuntAndKill4 {
@@ -41,7 +41,7 @@ impl HuntAndKill4 {
             return (grid, visitor.into_steps());
         }
 
-        let mut rng = self.rng.clone();
+        let mut rng = StdRng::seed_from_u64(self.rng_seed);
         let mut current = Some(GridCoord2D::new(
             rng.random_range(0..width),
             rng.random_range(0..height),
@@ -97,7 +97,7 @@ impl HuntAndKill4 {
 impl MazeGenerator2D for HuntAndKill4 {
     fn new_random() -> Self {
         Self {
-            rng: StdRng::from_os_rng(),
+            rng_seed: rand::random(),
         }
     }
 
@@ -105,9 +105,7 @@ impl MazeGenerator2D for HuntAndKill4 {
         if rng_seed == 0 {
             Self::new_random()
         } else {
-            Self {
-                rng: StdRng::seed_from_u64(rng_seed),
-            }
+            Self { rng_seed }
         }
     }
 

--- a/amaze/src/generators/kruskal4.rs
+++ b/amaze/src/generators/kruskal4.rs
@@ -9,7 +9,7 @@ use rand::prelude::SliceRandom;
 use rand::rngs::StdRng;
 
 pub struct Kruskal4 {
-    rng: StdRng,
+    rng_seed: u64,
 }
 
 impl Default for Kruskal4 {
@@ -44,7 +44,7 @@ impl Kruskal4 {
             }
         }
 
-        let mut rng = self.rng.clone();
+        let mut rng = StdRng::seed_from_u64(self.rng_seed);
         edges.shuffle(&mut rng);
 
         let mut uf = UnionFind::new(width * height);
@@ -65,7 +65,7 @@ impl Kruskal4 {
 impl MazeGenerator2D for Kruskal4 {
     fn new_random() -> Self {
         Self {
-            rng: StdRng::from_os_rng(),
+            rng_seed: rand::random(),
         }
     }
 
@@ -73,9 +73,7 @@ impl MazeGenerator2D for Kruskal4 {
         if rng_seed == 0 {
             Self::new_random()
         } else {
-            Self {
-                rng: StdRng::seed_from_u64(rng_seed),
-            }
+            Self { rng_seed }
         }
     }
 

--- a/amaze/src/generators/recursive_backtracker4.rs
+++ b/amaze/src/generators/recursive_backtracker4.rs
@@ -10,7 +10,7 @@ use rand::rngs::StdRng;
 
 /// A maze generator that implements the Recursive Backtracking algorithm.
 pub struct RecursiveBacktracker4 {
-    rng: StdRng,
+    rng_seed: u64,
 }
 
 impl Default for RecursiveBacktracker4 {
@@ -22,7 +22,7 @@ impl Default for RecursiveBacktracker4 {
 impl RecursiveBacktracker4 {
     pub fn new_random() -> Self {
         Self {
-            rng: StdRng::from_os_rng(),
+            rng_seed: rand::random(),
         }
     }
 
@@ -30,9 +30,7 @@ impl RecursiveBacktracker4 {
         if rng_seed == 0 {
             Self::new_random()
         } else {
-            Self {
-                rng: StdRng::seed_from_u64(rng_seed),
-            }
+            Self { rng_seed }
         }
     }
 
@@ -56,7 +54,7 @@ impl RecursiveBacktracker4 {
             return (cells, visitor.into_steps());
         }
 
-        let rng = self.rng.clone();
+        let rng = StdRng::seed_from_u64(self.rng_seed);
         Self::backtrack(
             rng,
             &mut cells,

--- a/amaze/src/generators/sidewinder4.rs
+++ b/amaze/src/generators/sidewinder4.rs
@@ -4,10 +4,10 @@ use crate::generators::{
 use crate::grid_coord_2d::GridCoord2D;
 use crate::wall4_grid::Wall4Grid;
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 
 pub struct Sidewinder4 {
-    rng: StdRng,
+    rng_seed: u64,
 }
 
 impl Default for Sidewinder4 {
@@ -25,7 +25,7 @@ impl Sidewinder4 {
             return (grid, visitor.into_steps());
         }
 
-        let mut rng = self.rng.clone();
+        let mut rng = StdRng::seed_from_u64(self.rng_seed);
         for y in 0..height {
             let mut run_start = 0usize;
             for x in 0..width {
@@ -61,7 +61,7 @@ impl Sidewinder4 {
 impl MazeGenerator2D for Sidewinder4 {
     fn new_random() -> Self {
         Self {
-            rng: StdRng::from_os_rng(),
+            rng_seed: rand::random(),
         }
     }
 
@@ -69,9 +69,7 @@ impl MazeGenerator2D for Sidewinder4 {
         if rng_seed == 0 {
             Self::new_random()
         } else {
-            Self {
-                rng: StdRng::seed_from_u64(rng_seed),
-            }
+            Self { rng_seed }
         }
     }
 

--- a/amaze/src/generators/wilson4.rs
+++ b/amaze/src/generators/wilson4.rs
@@ -5,11 +5,11 @@ use crate::grid_coord_2d::GridCoord2D;
 use crate::visit_map_2d::VisitMap2D;
 use crate::wall4_grid::Wall4Grid;
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{Rng, RngExt, SeedableRng};
 use std::collections::{HashMap, HashSet};
 
 pub struct Wilson4 {
-    rng: StdRng,
+    rng_seed: u64,
 }
 
 impl Default for Wilson4 {
@@ -32,7 +32,7 @@ impl Wilson4 {
             return (grid, visitor.into_steps());
         }
 
-        let mut rng = self.rng.clone();
+        let mut rng = StdRng::seed_from_u64(self.rng_seed);
         let all_cells: Vec<_> = grid.coords().collect();
         let mut in_maze = VisitMap2D::new_like(&grid);
 
@@ -91,7 +91,7 @@ impl Wilson4 {
 impl MazeGenerator2D for Wilson4 {
     fn new_random() -> Self {
         Self {
-            rng: StdRng::from_os_rng(),
+            rng_seed: rand::random(),
         }
     }
 
@@ -99,9 +99,7 @@ impl MazeGenerator2D for Wilson4 {
         if rng_seed == 0 {
             Self::new_random()
         } else {
-            Self {
-                rng: StdRng::seed_from_u64(rng_seed),
-            }
+            Self { rng_seed }
         }
     }
 


### PR DESCRIPTION
## Summary
- Centralize crate dependency definitions in root `Cargo.toml` via `[workspace.dependencies]` and migrate `amaze`, `amaze-cli`, and `amaze-gui` to `*.workspace = true` while preserving optional/feature behavior.
- Apply dependency upgrades from PR #5 (`rand` to `^0.10.1`, `criterion` to `0.8`) and refresh `Cargo.lock`.
- Preserve PR #3 intent by keeping `bytes` at `1.11.1` after lock refresh, with minimal source compatibility updates required by `rand 0.10` API changes.

## Verification
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo bench --no-run`