### PR TITLE
Add Chambers room-and-corridor dungeon generator

### DIFF
--- a/Taskfile.dist.yaml
+++ b/Taskfile.dist.yaml
@@ -6,45 +6,62 @@ vars:
   DEFAULT_SEED: "1337"
   DEFAULT_WIDTH: "18"
   DEFAULT_HEIGHT: "24"
+  DUNGEON_TYPE: chambers
+  DUNGEON_WIDTH: "50"
+  DUNGEON_HEIGHT: "30"
 
 tasks:
+  default:
+    desc: List available tasks
+    cmds:
+      - task --list --sort=none
+    silent: true
+
   fmt:
     desc: Format the code
+    aliases:
+      - format
     preconditions:
-      - sh: command -v cargo >/dev/null 2>&1
+      - &cargo
+        sh: command -v cargo >/dev/null 2>&1
         msg: cargo is not installed. Please install Rust via https://rustup.rs
     cmds:
       - cargo fmt
 
+  fmt:check:
+    desc: Check formatting without modifying files
+    preconditions:
+      - *cargo
+    cmds:
+      - cargo fmt --check
+
   lint:
     desc: Lint the code
     preconditions:
-      - sh: command -v cargo >/dev/null 2>&1
-        msg: cargo is not installed. Please install Rust via https://rustup.rs
+      - *cargo
     cmds:
-      - cargo clippy
+      - cargo clippy --workspace --all-targets
 
   lint:fix:
-    desc: Lint the code
+    desc: Lint the code and apply fixes
+    aliases:
+      - fix
     preconditions:
-      - sh: command -v cargo >/dev/null 2>&1
-        msg: cargo is not installed. Please install Rust via https://rustup.rs
+      - *cargo
     cmds:
-      - cargo clippy --fix --allow-staged
+      - cargo clippy --fix --allow-staged --workspace --all-targets
 
   test:
     desc: Run all tests
     preconditions:
-      - sh: command -v cargo >/dev/null 2>&1
-        msg: cargo is not installed. Please install Rust via https://rustup.rs
+      - *cargo
     cmds:
-      - cargo test -p amaze
+      - cargo test --workspace {{.CLI_ARGS}}
 
   build:
     desc: Build the workspace
     preconditions:
-      - sh: command -v cargo >/dev/null 2>&1
-        msg: cargo is not installed. Please install Rust via https://rustup.rs
+      - *cargo
     sources:
       - Cargo.lock
       - Cargo.toml
@@ -60,6 +77,28 @@ tasks:
     cmds:
       - cargo build
 
+  check:
+    desc: Run all static checks (format + lint)
+    cmds:
+      - task: fmt:check
+      - task: lint
+
+  ci:
+    desc: Run the full CI sequence (checks, tests, build)
+    cmds:
+      - task: check
+      - task: test
+      - task: build
+
+  clean:
+    desc: Remove build output
+    preconditions:
+      - *cargo
+    status:
+      - test ! -d target
+    cmds:
+      - cargo clean
+
   run:
     desc: Show the maze GUI
     aliases:
@@ -68,8 +107,7 @@ tasks:
       - show-gui
       - example:gui
     preconditions:
-      - sh: command -v cargo >/dev/null 2>&1
-        msg: cargo is not installed. Please install Rust via https://rustup.rs
+      - *cargo
     cmds:
       - cargo run --release --bin amaze-gui
 
@@ -80,8 +118,7 @@ tasks:
       - terminal
       - example:cli
     preconditions:
-      - sh: command -v cargo >/dev/null 2>&1
-        msg: cargo is not installed. Please install Rust via https://rustup.rs
+      - *cargo
     cmds:
       - >-
         cargo run --bin amaze-cli -- gen
@@ -90,6 +127,21 @@ tasks:
         --height {{default .DEFAULT_HEIGHT .HEIGHT}}
         --style {{default .DEFAULT_STYLE .STYLE}}
 
+  run:dungeon:
+    desc: Render a dungeon in terminal output
+    aliases:
+      - dungeon
+      - example:dungeon
+    preconditions:
+      - *cargo
+    cmds:
+      - >-
+        cargo run --bin amaze-cli -- gen-dungeon
+        --type {{default .DUNGEON_TYPE .TYPE}}
+        --seed {{default .DEFAULT_SEED .SEED}}
+        --width {{default .DUNGEON_WIDTH .WIDTH}}
+        --height {{default .DUNGEON_HEIGHT .HEIGHT}}
+
   run:ppm:
     desc: Render a maze in PPM format
     aliases:
@@ -97,8 +149,7 @@ tasks:
       - example:ppm
       - show-example-ppm
     preconditions:
-      - sh: command -v cargo >/dev/null 2>&1
-        msg: cargo is not installed. Please install Rust via https://rustup.rs
+      - *cargo
     cmds:
       - >-
         cargo run --bin amaze-cli -- gen
@@ -114,8 +165,7 @@ tasks:
       - example:pbm
       - show-example-pbm
     preconditions:
-      - sh: command -v cargo >/dev/null 2>&1
-        msg: cargo is not installed. Please install Rust via https://rustup.rs
+      - *cargo
     cmds:
       - >-
         cargo run --bin amaze-cli -- gen
@@ -129,8 +179,7 @@ tasks:
     aliases:
       - doc
     preconditions:
-      - sh: command -v cargo >/dev/null 2>&1
-        msg: cargo is not installed. Please install Rust via https://rustup.rs
+      - *cargo
     cmds:
       - "cargo doc --no-deps --all-features"
 
@@ -139,7 +188,6 @@ tasks:
     aliases:
       - doc:open
     preconditions:
-      - sh: command -v cargo >/dev/null 2>&1
-        msg: cargo is not installed. Please install Rust via https://rustup.rs
+      - *cargo
     cmds:
       - "cargo doc --no-deps --all-features --open"

--- a/amaze-cli/src/main.rs
+++ b/amaze-cli/src/main.rs
@@ -1,4 +1,6 @@
-use amaze::dungeon::{DungeonGrid, DungeonType, DungeonWalkGenerator, TileType};
+use amaze::dungeon::{
+    DungeonGrid, DungeonType, DungeonWalkGenerator, RoomCorridorGenerator, TileType,
+};
 #[cfg(feature = "generators-hex")]
 use amaze::generators::{AldousBroder6, GrowingTree6, MazeGenerator6D, RecursiveBacktracker6};
 use amaze::generators::{
@@ -92,7 +94,7 @@ fn main() {
                         .help("selects the dungeon type")
                         .display_order(0)
                         .default_value("rooms")
-                        .value_parser(["caverns", "rooms", "winding"])
+                        .value_parser(["caverns", "rooms", "winding", "chambers"])
                         .action(ArgAction::Set),
                 )
                 .arg(
@@ -348,28 +350,39 @@ fn main() {
             let dungeon_type_str = dungeon_matches
                 .get_one::<String>("type")
                 .expect("defaulted");
-            let dungeon_type = match dungeon_type_str.as_str() {
-                "caverns" => DungeonType::Caverns,
-                "rooms" => DungeonType::Rooms,
-                "winding" => DungeonType::Winding,
-                _ => unreachable!(),
-            };
 
-            let dungeon = DungeonWalkGenerator::new_from_seed(dungeon_type, seed)
-                .with_winding_probability(winding_probability)
-                .with_long_walk_range(long_walk_min, long_walk_max)
-                .with_dynamic_resize(*dungeon_matches.get_one::<bool>("dynamic").unwrap_or(&false))
-                .with_initial_grid_size(
-                    *dungeon_matches
-                        .get_one::<usize>("initial-size")
-                        .unwrap_or(&32),
-                )
-                .with_trim_padding(
-                    *dungeon_matches
-                        .get_one::<usize>("trim-padding")
-                        .unwrap_or(&0),
-                )
-                .generate(width, height, floor_count);
+            let trim_padding = *dungeon_matches
+                .get_one::<usize>("trim-padding")
+                .unwrap_or(&0);
+
+            // Chambers uses the placement-based RoomCorridorGenerator; the other
+            // types use the walk-based DungeonWalkGenerator.
+            let dungeon = if dungeon_type_str == "chambers" {
+                RoomCorridorGenerator::new_from_seed(seed)
+                    .with_trim_padding(trim_padding)
+                    .generate(width, height)
+            } else {
+                let dungeon_type = match dungeon_type_str.as_str() {
+                    "caverns" => DungeonType::Caverns,
+                    "rooms" => DungeonType::Rooms,
+                    "winding" => DungeonType::Winding,
+                    _ => unreachable!(),
+                };
+
+                DungeonWalkGenerator::new_from_seed(dungeon_type, seed)
+                    .with_winding_probability(winding_probability)
+                    .with_long_walk_range(long_walk_min, long_walk_max)
+                    .with_dynamic_resize(
+                        *dungeon_matches.get_one::<bool>("dynamic").unwrap_or(&false),
+                    )
+                    .with_initial_grid_size(
+                        *dungeon_matches
+                            .get_one::<usize>("initial-size")
+                            .unwrap_or(&32),
+                    )
+                    .with_trim_padding(trim_padding)
+                    .generate(width, height, floor_count)
+            };
 
             println!("{}", render_dungeon(&dungeon));
         }

--- a/amaze-gui/src/main.rs
+++ b/amaze-gui/src/main.rs
@@ -1,4 +1,6 @@
-use amaze::dungeon::{DungeonGrid, DungeonType, DungeonWalkGenerator, TileType, solve_bfs};
+use amaze::dungeon::{
+    DungeonGrid, DungeonType, DungeonWalkGenerator, RoomCorridorGenerator, TileType, solve_bfs,
+};
 #[cfg(feature = "generators-hex")]
 use amaze::generators::{
     AldousBroder6, GrowingTree6, HexGenerationStep, MazeGenerator6D, RecursiveBacktracker6,
@@ -307,6 +309,7 @@ impl App for MyApp {
                         DungeonType::Caverns => "Caverns",
                         DungeonType::Rooms => "Rooms",
                         DungeonType::Winding => "Winding",
+                        DungeonType::Chambers => "Chambers",
                     })
                     .show_ui(ui, |ui| {
                         ui.selectable_value(
@@ -319,6 +322,11 @@ impl App for MyApp {
                             &mut self.dungeon_type,
                             DungeonType::Winding,
                             "Winding",
+                        );
+                        ui.selectable_value(
+                            &mut self.dungeon_type,
+                            DungeonType::Chambers,
+                            "Chambers",
                         );
                     });
 
@@ -706,10 +714,14 @@ fn regenerate_dungeon(app: &mut MyApp) {
     app.end_cell = None;
     app.auto_fit_pending = true;
     let mut lock = app.dungeon.lock().unwrap();
-    *lock = DungeonWalkGenerator::new_from_seed(app.dungeon_type, app.seed)
-        .with_winding_probability(app.winding_probability)
-        .with_long_walk_range(app.long_walk_min, app.long_walk_max)
-        .generate(app.width, app.height, app.floor_count);
+    *lock = if app.dungeon_type == DungeonType::Chambers {
+        RoomCorridorGenerator::new_from_seed(app.seed).generate(app.width, app.height)
+    } else {
+        DungeonWalkGenerator::new_from_seed(app.dungeon_type, app.seed)
+            .with_winding_probability(app.winding_probability)
+            .with_long_walk_range(app.long_walk_min, app.long_walk_max)
+            .generate(app.width, app.height, app.floor_count)
+    };
 }
 
 fn render_maze(ui: &mut egui::Ui, app: &mut MyApp, ctx: &egui::Context) {

--- a/amaze/src/dungeon.rs
+++ b/amaze/src/dungeon.rs
@@ -8,6 +8,7 @@ mod dungeon_grid;
 mod dungeon_type;
 mod dyn_dungeon_grid;
 pub mod generators;
+pub mod room_corridor;
 #[cfg(all(feature = "representations", feature = "solvers"))]
 pub mod solvers;
 mod tile_type;
@@ -19,6 +20,7 @@ pub use generators::{
     DungeonGenerationStep, DungeonGenerationSteps, DungeonGenerationVisitor, DungeonGenerator,
     DungeonWalkGenerator, VecDungeonGenerationVisitor,
 };
+pub use room_corridor::{RoomCorridorGenerator, RoomTag};
 #[cfg(all(feature = "representations", feature = "solvers"))]
 pub use solvers::{solve_astar, solve_bfs};
 pub use tile_type::TileType;

--- a/amaze/src/dungeon/dungeon_grid.rs
+++ b/amaze/src/dungeon/dungeon_grid.rs
@@ -179,6 +179,15 @@ impl DungeonGrid {
     ///
     /// If no non-Empty tiles exist, returns a minimal 1x1 Empty grid.
     pub fn trim(&self, padding: usize) -> Self {
+        self.trim_with_offset(padding).0
+    }
+
+    /// Like [`trim`](Self::trim), but also returns the top-left origin (in the
+    /// original grid's coordinates) that the trimmed grid was cropped to.
+    ///
+    /// Subtracting this offset from any original coordinate maps it into the
+    /// trimmed grid's coordinate space. For an empty grid the offset is `(0, 0)`.
+    pub fn trim_with_offset(&self, padding: usize) -> (Self, GridCoord2D) {
         // Find bounding box of all non-Empty tiles
         let mut min_x = usize::MAX;
         let mut min_y = usize::MAX;
@@ -208,7 +217,7 @@ impl DungeonGrid {
         }
 
         if !has_content {
-            return DungeonGrid::new(1, 1);
+            return (DungeonGrid::new(1, 1), GridCoord2D::new(0, 0));
         }
 
         // Apply padding and clamp to original bounds
@@ -251,7 +260,7 @@ impl DungeonGrid {
         // Recompute edge masks
         final_grid.compute_edge_masks();
 
-        final_grid
+        (final_grid, GridCoord2D::new(content_min_x, content_min_y))
     }
 }
 

--- a/amaze/src/dungeon/dungeon_type.rs
+++ b/amaze/src/dungeon/dungeon_type.rs
@@ -8,6 +8,8 @@ pub enum DungeonType {
     Rooms,
     /// Winding corridors with probabilistic room suppression
     Winding,
+    /// Discrete, non-overlapping rooms joined by explicit corridors
+    Chambers,
 }
 
 impl DungeonType {
@@ -17,6 +19,7 @@ impl DungeonType {
             DungeonType::Caverns => "Caverns",
             DungeonType::Rooms => "Rooms",
             DungeonType::Winding => "Winding",
+            DungeonType::Chambers => "Chambers",
         }
     }
 
@@ -26,6 +29,7 @@ impl DungeonType {
             DungeonType::Caverns => "Unconstrained random walk creating organic caverns",
             DungeonType::Rooms => "Long corridors connecting rectangular rooms",
             DungeonType::Winding => "Winding corridors with occasional rooms",
+            DungeonType::Chambers => "Discrete rooms joined by corridors",
         }
     }
 }

--- a/amaze/src/dungeon/generators.rs
+++ b/amaze/src/dungeon/generators.rs
@@ -1,5 +1,6 @@
 use crate::dungeon::{DungeonGrid, DungeonType, DynDungeonGrid, TileType};
 use crate::grid_coord_2d::{GetCoordinateBounds2D, GridCoord2D};
+use crate::grid_rect::GridRect;
 use rand::prelude::IndexedRandom;
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
@@ -16,6 +17,10 @@ pub enum DungeonGenerationStep {
         half_width: usize,
         half_height: usize,
     },
+    /// A non-overlapping room was placed (Chambers generation)
+    PlaceRoom { rect: GridRect },
+    /// A corridor connecting two rooms was placed (Chambers generation)
+    PlaceCorridor { rect: GridRect },
     /// A wall was placed
     PlaceWall { coord: GridCoord2D },
     /// Exit position was set
@@ -331,7 +336,9 @@ impl DungeonWalkGenerator {
                         last_floor_pos = walker_pos;
                     }
                 }
-                DungeonType::Rooms | DungeonType::Winding => {
+                // Chambers is produced by RoomCorridorGenerator; if it ever
+                // reaches the walk generator, fall back to Rooms-style stamping.
+                DungeonType::Rooms | DungeonType::Winding | DungeonType::Chambers => {
                     let mut ctx = WalkContext {
                         rng,
                         grid: &mut grid,
@@ -343,11 +350,11 @@ impl DungeonWalkGenerator {
 
                     walker_pos = self.take_long_walk(&mut ctx, walker_pos, target_floor_count);
 
-                    let should_stamp_room = if self.dungeon_type == DungeonType::Rooms {
-                        true
-                    } else {
+                    let should_stamp_room = if self.dungeon_type == DungeonType::Winding {
                         let roll = ctx.rng.random_range(0..100);
                         roll > self.winding_hall_probability
+                    } else {
+                        true
                     };
 
                     if should_stamp_room && ctx.grid.floor_count() < target_floor_count {
@@ -449,7 +456,9 @@ impl DungeonWalkGenerator {
                         last_floor_world = walker_world;
                     }
                 }
-                DungeonType::Rooms | DungeonType::Winding => {
+                // Chambers is produced by RoomCorridorGenerator; if it ever
+                // reaches the walk generator, fall back to Rooms-style stamping.
+                DungeonType::Rooms | DungeonType::Winding | DungeonType::Chambers => {
                     let mut ctx = DynWalkContext {
                         rng,
                         dyn_grid: &mut dyn_grid,
@@ -461,11 +470,11 @@ impl DungeonWalkGenerator {
                     walker_world =
                         self.take_long_walk_world(&mut ctx, walker_world, target_floor_count);
 
-                    let should_stamp_room = if self.dungeon_type == DungeonType::Rooms {
-                        true
-                    } else {
+                    let should_stamp_room = if self.dungeon_type == DungeonType::Winding {
                         let roll = ctx.rng.random_range(0..100);
                         roll > self.winding_hall_probability
+                    } else {
+                        true
                     };
 
                     if should_stamp_room && ctx.dyn_grid.inner().floor_count() < target_floor_count

--- a/amaze/src/dungeon/room_corridor.rs
+++ b/amaze/src/dungeon/room_corridor.rs
@@ -1,0 +1,607 @@
+use crate::direction4::Direction4;
+use crate::dungeon::generators::{
+    DungeonGenerationStep, DungeonGenerationSteps, DungeonGenerationVisitor, DungeonGenerator,
+    VecDungeonGenerationVisitor,
+};
+use crate::dungeon::{DungeonGrid, DungeonType, TileType};
+use crate::grid_coord_2d::GridCoord2D;
+use crate::grid_rect::GridRect;
+use crate::room4_list::{Room4List, RoomIndex};
+use rand::rngs::StdRng;
+use rand::{RngExt, SeedableRng};
+
+/// Application data attached to each room in the generated connectivity graph.
+///
+/// The tag is intentionally coordinate-free: room positions live in the
+/// pre-trim layout space, while the returned [`DungeonGrid`] is trimmed to its
+/// content bounds. Keeping only the room dimensions here means the
+/// [`Room4List`] graph stays purely topological and cannot desync from the grid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RoomTag {
+    /// Room width in cells.
+    pub width: usize,
+    /// Room height in cells.
+    pub height: usize,
+}
+
+/// The internal placement result: discrete rooms joined by corridors.
+struct Layout {
+    rooms: Vec<GridRect>,
+    corridors: Vec<GridRect>,
+    /// `dirs[i]` is the cardinal direction leading from `rooms[i]` to `rooms[i + 1]`.
+    dirs: Vec<Direction4>,
+}
+
+/// Generator producing discrete, non-overlapping rectangular rooms connected by
+/// explicit corridors.
+///
+/// Unlike [`DungeonWalkGenerator`](crate::dungeon::DungeonWalkGenerator), which
+/// carves space by walking and stamping (rooms can merge), this generator
+/// *places* rooms with collision detection and backtracking, so every room is a
+/// distinct chamber reached through a corridor. It is also the first dungeon
+/// generator to expose a [`Room4List`] connectivity graph alongside the tile
+/// grid (see [`generate_with_graph`](RoomCorridorGenerator::generate_with_graph)).
+///
+/// Corridors run in the four cardinal directions, mapping naturally onto
+/// [`Room4`](crate::room4::Room4)'s `Direction4` neighbour links.
+pub struct RoomCorridorGenerator {
+    rng_seed: u64,
+    room_count_min: usize,
+    room_count_max: usize,
+    room_size_min: usize,
+    room_size_max: usize,
+    corridor_length_min: usize,
+    corridor_length_max: usize,
+    corridor_width_min: usize,
+    corridor_width_max: usize,
+    trim_padding: usize,
+}
+
+impl RoomCorridorGenerator {
+    /// Create a generator with a random seed and sensible defaults.
+    pub fn new_random() -> Self {
+        Self::with_seed(rand::random())
+    }
+
+    /// Create a generator with a specific seed. A seed of `0` is replaced by a
+    /// random seed (matching [`DungeonWalkGenerator`](crate::dungeon::DungeonWalkGenerator)).
+    pub fn new_from_seed(seed: u64) -> Self {
+        Self::with_seed(if seed == 0 { rand::random() } else { seed })
+    }
+
+    fn with_seed(rng_seed: u64) -> Self {
+        // Defaults mirror dungen-unity's room/corridor ranges. The invariant
+        // `corridor_width_max <= room_size_min` keeps every corridor mouth
+        // coverable by the room it opens into.
+        Self {
+            rng_seed,
+            room_count_min: 6,
+            room_count_max: 12,
+            room_size_min: 4,
+            room_size_max: 8,
+            corridor_length_min: 3,
+            corridor_length_max: 8,
+            corridor_width_min: 1,
+            corridor_width_max: 3,
+            trim_padding: 0,
+        }
+    }
+
+    /// Set the inclusive range for the number of rooms to attempt.
+    pub fn with_room_count_range(mut self, min: usize, max: usize) -> Self {
+        let min = min.max(1);
+        self.room_count_min = min;
+        self.room_count_max = max.max(min);
+        self
+    }
+
+    /// Set the inclusive range for room side lengths (applies to both width and height).
+    ///
+    /// To keep corridors coverable, the corridor-width range is clamped so that
+    /// `corridor_width_max <= room_size_min`.
+    pub fn with_room_size_range(mut self, min: usize, max: usize) -> Self {
+        let min = min.max(1);
+        self.room_size_min = min;
+        self.room_size_max = max.max(min);
+        self.clamp_corridor_width();
+        self
+    }
+
+    /// Set the inclusive range for corridor lengths.
+    pub fn with_corridor_length_range(mut self, min: usize, max: usize) -> Self {
+        let min = min.max(1);
+        self.corridor_length_min = min;
+        self.corridor_length_max = max.max(min);
+        self
+    }
+
+    /// Set the inclusive range for corridor widths (perpendicular thickness).
+    ///
+    /// Values are clamped so that `corridor_width_max <= room_size_min`,
+    /// guaranteeing a corridor never opens onto a wall.
+    pub fn with_corridor_width_range(mut self, min: usize, max: usize) -> Self {
+        let min = min.max(1);
+        self.corridor_width_min = min;
+        self.corridor_width_max = max.max(min);
+        self.clamp_corridor_width();
+        self
+    }
+
+    /// Set the padding around the final trimmed dungeon.
+    pub fn with_trim_padding(mut self, padding: usize) -> Self {
+        self.trim_padding = padding;
+        self
+    }
+
+    fn clamp_corridor_width(&mut self) {
+        if self.corridor_width_max > self.room_size_min {
+            self.corridor_width_max = self.room_size_min;
+        }
+        if self.corridor_width_min > self.corridor_width_max {
+            self.corridor_width_min = self.corridor_width_max;
+        }
+    }
+
+    /// Generate a dungeon of discrete rooms joined by corridors.
+    pub fn generate(&self, width: usize, height: usize) -> DungeonGrid {
+        let (grid, _layout) = self.build(width, height);
+        grid
+    }
+
+    /// Generate a dungeon together with its room connectivity graph.
+    ///
+    /// The returned [`Room4List`] has one node per placed room, linked through
+    /// the cardinal directions of the corridors joining them. Rooms are pushed
+    /// in placement order; the first room is the start and the last is the exit.
+    pub fn generate_with_graph(
+        &self,
+        width: usize,
+        height: usize,
+    ) -> (DungeonGrid, Room4List<RoomTag>) {
+        let (grid, layout) = self.build(width, height);
+        let graph = build_graph(&layout);
+        (grid, graph)
+    }
+
+    /// Generate with step-by-step events for animation.
+    pub fn generate_steps(&self, width: usize, height: usize) -> DungeonGenerationSteps {
+        let mut visitor = VecDungeonGenerationVisitor::default();
+        let (_grid, layout) = self.build(width, height);
+
+        for (i, room) in layout.rooms.iter().enumerate() {
+            visitor.on_step(&DungeonGenerationStep::PlaceRoom { rect: *room });
+            if i < layout.corridors.len() {
+                visitor.on_step(&DungeonGenerationStep::PlaceCorridor {
+                    rect: layout.corridors[i],
+                });
+            }
+        }
+        if let Some(last) = layout.rooms.last() {
+            visitor.on_step(&DungeonGenerationStep::SetExit {
+                coord: last.center(),
+            });
+        }
+        visitor.on_step(&DungeonGenerationStep::Complete);
+
+        DungeonGenerationSteps::new(visitor.into_steps())
+    }
+
+    /// Run the placement algorithm and rasterize it into a trimmed grid.
+    fn build(&self, width: usize, height: usize) -> (DungeonGrid, Layout) {
+        let mut rng = StdRng::seed_from_u64(self.rng_seed);
+
+        if width == 0 || height == 0 {
+            return (
+                DungeonGrid::new(width, height),
+                Layout {
+                    rooms: Vec::new(),
+                    corridors: Vec::new(),
+                    dirs: Vec::new(),
+                },
+            );
+        }
+
+        let layout = self.build_layout(width, height, &mut rng);
+
+        let mut grid = DungeonGrid::new(width, height);
+        for rect in layout.rooms.iter().chain(layout.corridors.iter()) {
+            for coord in rect.coords() {
+                grid.set(coord, TileType::Floor);
+            }
+        }
+
+        // Exit is the last room placed (or any floor, if no rooms were placed).
+        if let Some(last) = layout.rooms.last() {
+            grid.set_exit(last.center());
+        }
+
+        // Reuse the shared trim -> place_walls -> compute_edge_masks pipeline.
+        let grid = grid.trim(self.trim_padding);
+        (grid, layout)
+    }
+
+    /// Port of dungen-unity's `DungeonGenerator.asBoard`: place a first room,
+    /// then repeatedly attach a corridor + room, rotating direction clockwise on
+    /// no-fit and backtracking the corridor when the next room cannot be placed.
+    fn build_layout(&self, width: usize, height: usize, rng: &mut StdRng) -> Layout {
+        let mut rooms: Vec<GridRect> = Vec::new();
+        let mut corridors: Vec<GridRect> = Vec::new();
+        let mut dirs: Vec<Direction4> = Vec::new();
+
+        let room_count = sample(rng, self.room_count_min, self.room_count_max);
+
+        // First room: placed at a random in-bounds position.
+        let (rw, rh) = self.sample_room_size(rng, width, height);
+        let ox = rng.random_range(0..(width - rw + 1));
+        let oy = rng.random_range(0..(height - rh + 1));
+        rooms.push(GridRect::new(GridCoord2D::new(ox, oy), rw, rh));
+
+        let cardinals = Direction4::CARDINALS; // [N, E, S, W]
+        let mut dir_idx = rng.random_range(0..4);
+        let mut room_retry = 0usize;
+        let mut placed = 1usize;
+
+        while placed < room_count {
+            // Fresh attempt picks a random direction; a retry rotates clockwise.
+            if room_retry == 0 {
+                dir_idx = rng.random_range(0..4);
+            } else {
+                dir_idx = (dir_idx + 1) % 4;
+            }
+
+            let source = *rooms.last().unwrap();
+            let source_idx = rooms.len() - 1;
+
+            // Try to fit a corridor, rotating clockwise up to four times.
+            let mut corridor = None;
+            for _ in 0..4 {
+                if let Some(c) = self.try_corridor(rng, &source, cardinals[dir_idx], width, height)
+                {
+                    if self.collision_free(&c, &rooms, &corridors, Some(source_idx)) {
+                        corridor = Some((c, cardinals[dir_idx]));
+                        break;
+                    }
+                }
+                dir_idx = (dir_idx + 1) % 4;
+            }
+
+            let (corridor_rect, dir) = match corridor {
+                Some(v) => v,
+                // No corridor fits in any direction: the layout is boxed in.
+                None => break,
+            };
+
+            // Try to place the next room at the far end of the corridor.
+            if let Some(room) = self.try_room(rng, &corridor_rect, dir, width, height) {
+                if self.collision_free(&room, &rooms, &corridors, None) {
+                    corridors.push(corridor_rect);
+                    rooms.push(room);
+                    dirs.push(dir);
+                    room_retry = 0;
+                    placed += 1;
+                    continue;
+                }
+            }
+
+            // Room did not fit: drop the corridor (backtrack) and retry.
+            if room_retry < 4 {
+                room_retry += 1;
+            } else {
+                break;
+            }
+        }
+
+        Layout {
+            rooms,
+            corridors,
+            dirs,
+        }
+    }
+
+    fn sample_room_size(&self, rng: &mut StdRng, width: usize, height: usize) -> (usize, usize) {
+        let rw = sample(rng, self.room_size_min, self.room_size_max)
+            .min(width)
+            .max(1);
+        let rh = sample(rng, self.room_size_min, self.room_size_max)
+            .min(height)
+            .max(1);
+        (rw, rh)
+    }
+
+    /// Build a corridor rectangle leaving `room` in `dir`. The corridor mouth is
+    /// kept within the room's edge so it always connects.
+    fn try_corridor(
+        &self,
+        rng: &mut StdRng,
+        room: &GridRect,
+        dir: Direction4,
+        width: usize,
+        height: usize,
+    ) -> Option<GridRect> {
+        let length = sample(rng, self.corridor_length_min, self.corridor_length_max);
+        let cwidth = sample(rng, self.corridor_width_min, self.corridor_width_max);
+
+        let rect = match dir {
+            Direction4::NORTH => {
+                if room.top() < length || room.width < cwidth {
+                    return None;
+                }
+                let ox = pick_in_room(rng, room.left(), room.right(), cwidth)?;
+                GridRect::new(GridCoord2D::new(ox, room.top() - length), cwidth, length)
+            }
+            Direction4::SOUTH => {
+                if room.width < cwidth {
+                    return None;
+                }
+                let ox = pick_in_room(rng, room.left(), room.right(), cwidth)?;
+                GridRect::new(GridCoord2D::new(ox, room.bottom() + 1), cwidth, length)
+            }
+            Direction4::EAST => {
+                if room.height < cwidth {
+                    return None;
+                }
+                let oy = pick_in_room(rng, room.top(), room.bottom(), cwidth)?;
+                GridRect::new(GridCoord2D::new(room.right() + 1, oy), length, cwidth)
+            }
+            Direction4::WEST => {
+                if room.left() < length || room.height < cwidth {
+                    return None;
+                }
+                let oy = pick_in_room(rng, room.top(), room.bottom(), cwidth)?;
+                GridRect::new(GridCoord2D::new(room.left() - length, oy), length, cwidth)
+            }
+            _ => return None,
+        };
+
+        if rect.right() < width && rect.bottom() < height {
+            Some(rect)
+        } else {
+            None
+        }
+    }
+
+    /// Build a room rectangle at the far end of `corridor`, fully covering the
+    /// corridor mouth so the two connect.
+    fn try_room(
+        &self,
+        rng: &mut StdRng,
+        corridor: &GridRect,
+        dir: Direction4,
+        width: usize,
+        height: usize,
+    ) -> Option<GridRect> {
+        let (rw, rh) = self.sample_room_size(rng, width, height);
+
+        let rect = match dir {
+            Direction4::NORTH => {
+                if corridor.top() < rh {
+                    return None;
+                }
+                let ox = cover_span(rng, corridor.left(), corridor.right(), rw, width)?;
+                GridRect::new(GridCoord2D::new(ox, corridor.top() - rh), rw, rh)
+            }
+            Direction4::SOUTH => {
+                let ox = cover_span(rng, corridor.left(), corridor.right(), rw, width)?;
+                GridRect::new(GridCoord2D::new(ox, corridor.bottom() + 1), rw, rh)
+            }
+            Direction4::EAST => {
+                let oy = cover_span(rng, corridor.top(), corridor.bottom(), rh, height)?;
+                GridRect::new(GridCoord2D::new(corridor.right() + 1, oy), rw, rh)
+            }
+            Direction4::WEST => {
+                if corridor.left() < rw {
+                    return None;
+                }
+                let oy = cover_span(rng, corridor.top(), corridor.bottom(), rh, height)?;
+                GridRect::new(GridCoord2D::new(corridor.left() - rw, oy), rw, rh)
+            }
+            _ => return None,
+        };
+
+        if rect.right() < width && rect.bottom() < height {
+            Some(rect)
+        } else {
+            None
+        }
+    }
+
+    /// True if `rect` collides with no placed room (except `skip_room`) or corridor.
+    fn collision_free(
+        &self,
+        rect: &GridRect,
+        rooms: &[GridRect],
+        corridors: &[GridRect],
+        skip_room: Option<usize>,
+    ) -> bool {
+        for (i, r) in rooms.iter().enumerate() {
+            if Some(i) == skip_room {
+                continue;
+            }
+            if rect.collides(r) {
+                return false;
+            }
+        }
+        !corridors.iter().any(|c| rect.collides(c))
+    }
+}
+
+/// Sample an inclusive range `[min, max]`.
+fn sample(rng: &mut StdRng, min: usize, max: usize) -> usize {
+    rng.random_range(min..max + 1)
+}
+
+/// Pick a corridor origin so a `thickness`-wide corridor lies within the room
+/// span `[lo, hi]` (i.e. the corridor mouth is fully on the room's edge).
+fn pick_in_room(rng: &mut StdRng, lo: usize, hi: usize, thickness: usize) -> Option<usize> {
+    // Origin range: [lo, hi + 1 - thickness].
+    let max_origin = (hi + 1).checked_sub(thickness)?;
+    if max_origin < lo {
+        return None;
+    }
+    Some(rng.random_range(lo..max_origin + 1))
+}
+
+/// Pick a room origin so a `room_len`-long side fully covers the span `[lo, hi]`
+/// while staying within `max_extent`.
+fn cover_span(
+    rng: &mut StdRng,
+    lo: usize,
+    hi: usize,
+    room_len: usize,
+    max_extent: usize,
+) -> Option<usize> {
+    // Need origin o with: o <= lo (covers lo) and o + room_len - 1 >= hi (covers hi).
+    let min_origin = (hi + 1).saturating_sub(room_len);
+    let max_origin = lo.min(max_extent.checked_sub(room_len)?);
+    if min_origin > max_origin {
+        return None;
+    }
+    Some(rng.random_range(min_origin..max_origin + 1))
+}
+
+/// Build the room connectivity graph from a placement layout.
+fn build_graph(layout: &Layout) -> Room4List<RoomTag> {
+    let mut list = Room4List::default();
+    let mut indices: Vec<RoomIndex> = Vec::with_capacity(layout.rooms.len());
+
+    for (i, room) in layout.rooms.iter().enumerate() {
+        let tag = RoomTag {
+            width: room.width,
+            height: room.height,
+        };
+        let idx = if i == 0 {
+            list.push_default(tag)
+        } else {
+            let prev = indices[i - 1];
+            let dir = layout.dirs[i - 1]; // direction prev -> this
+            // Link this room back toward its predecessor; Room4List propagates
+            // the reciprocal link (prev gains a neighbour in `dir`).
+            list.push_new(tag, |room4| {
+                room4.set_room(dir.opposite(), Some(prev));
+            })
+        };
+        indices.push(idx);
+    }
+
+    list
+}
+
+impl DungeonGenerator for RoomCorridorGenerator {
+    fn new_random() -> Self {
+        RoomCorridorGenerator::new_random()
+    }
+
+    fn new_from_seed(seed: u64) -> Self {
+        RoomCorridorGenerator::new_from_seed(seed)
+    }
+
+    /// Generate a dungeon. `floor_count` is ignored — room count is controlled
+    /// via [`with_room_count_range`](RoomCorridorGenerator::with_room_count_range).
+    fn generate(&self, width: usize, height: usize, _floor_count: usize) -> DungeonGrid {
+        RoomCorridorGenerator::generate(self, width, height)
+    }
+
+    fn generate_steps(
+        &self,
+        width: usize,
+        height: usize,
+        _floor_count: usize,
+    ) -> DungeonGenerationSteps {
+        RoomCorridorGenerator::generate_steps(self, width, height)
+    }
+
+    fn dungeon_type(&self) -> DungeonType {
+        DungeonType::Chambers
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grid_coord_2d::GetCoordinateBounds2D;
+
+    fn all_rects(layout_grid: &DungeonGrid) -> usize {
+        layout_grid.floor_count()
+    }
+
+    #[test]
+    fn produces_floors_and_exit() {
+        let generator = RoomCorridorGenerator::new_from_seed(42);
+        let grid = generator.generate(60, 60);
+        assert!(all_rects(&grid) > 0, "should carve floor tiles");
+        assert!(grid.exit().is_some(), "should set an exit");
+    }
+
+    #[test]
+    fn same_seed_is_deterministic() {
+        let g1 = RoomCorridorGenerator::new_from_seed(7).generate(60, 60);
+        let g2 = RoomCorridorGenerator::new_from_seed(7).generate(60, 60);
+        let f1: std::collections::HashSet<_> = g1.floor_iter().collect();
+        let f2: std::collections::HashSet<_> = g2.floor_iter().collect();
+        assert_eq!(f1, f2);
+        assert_eq!(g1.exit(), g2.exit());
+    }
+
+    #[test]
+    fn rooms_never_overlap() {
+        // Inspect the raw layout: no two rooms may collide (overlap or touch),
+        // and no room may collide with a corridor it is not connected to.
+        let generator = RoomCorridorGenerator::new_from_seed(123);
+        let mut rng = StdRng::seed_from_u64(generator.rng_seed);
+        let layout = generator.build_layout(80, 80, &mut rng);
+
+        for (i, a) in layout.rooms.iter().enumerate() {
+            for b in layout.rooms.iter().skip(i + 1) {
+                assert!(!a.collides(b), "rooms {a:?} and {b:?} collide");
+            }
+        }
+    }
+
+    #[test]
+    fn tiny_bounds_terminate_without_panic() {
+        // A box too small for the configured rooms must not loop or panic.
+        let generator = RoomCorridorGenerator::new_from_seed(1)
+            .with_room_size_range(3, 4)
+            .with_corridor_width_range(1, 2)
+            .with_room_count_range(10, 10);
+        let grid = generator.generate(12, 12);
+        assert!(grid.width() > 0 && grid.height() > 0);
+    }
+
+    #[test]
+    fn corridor_width_clamped_to_room_min() {
+        let generator = RoomCorridorGenerator::new_from_seed(1)
+            .with_room_size_range(3, 6)
+            .with_corridor_width_range(5, 9);
+        assert!(generator.corridor_width_max <= generator.room_size_min);
+    }
+
+    #[test]
+    fn graph_links_are_bidirectional() {
+        let generator = RoomCorridorGenerator::new_from_seed(99).with_room_count_range(4, 4);
+        let (_grid, graph) = generator.generate_with_graph(80, 80);
+        assert!(!graph.is_empty(), "graph should have rooms");
+
+        // Every room except endpoints has at least one door; reciprocal links hold.
+        for room in graph.iter() {
+            for dir in [
+                Direction4::NORTH,
+                Direction4::SOUTH,
+                Direction4::EAST,
+                Direction4::WEST,
+            ] {
+                if let Some(neighbor_idx) = room.get_neighbor(dir) {
+                    let neighbor = &graph[neighbor_idx];
+                    assert_eq!(
+                        neighbor.get_neighbor(dir.opposite()),
+                        Some(room.index()),
+                        "link from {:?} in {:?} not reciprocated",
+                        room.index(),
+                        dir
+                    );
+                }
+            }
+        }
+    }
+}

--- a/amaze/src/dungeon/room_corridor.rs
+++ b/amaze/src/dungeon/room_corridor.rs
@@ -145,7 +145,7 @@ impl RoomCorridorGenerator {
 
     /// Generate a dungeon of discrete rooms joined by corridors.
     pub fn generate(&self, width: usize, height: usize) -> DungeonGrid {
-        let (grid, _layout) = self.build(width, height);
+        let (grid, _layout, _offset) = self.build(width, height);
         grid
     }
 
@@ -159,28 +159,40 @@ impl RoomCorridorGenerator {
         width: usize,
         height: usize,
     ) -> (DungeonGrid, Room4List<RoomTag>) {
-        let (grid, layout) = self.build(width, height);
+        let (grid, layout, _offset) = self.build(width, height);
         let graph = build_graph(&layout);
         (grid, graph)
     }
 
     /// Generate with step-by-step events for animation.
+    ///
+    /// Step coordinates are in the same space as the [`DungeonGrid`] returned by
+    /// [`generate`](Self::generate): rooms, corridors and the exit are rebased
+    /// onto the trimmed grid, so replaying the steps lines up with the final
+    /// dungeon even when `trim_padding` is non-zero.
     pub fn generate_steps(&self, width: usize, height: usize) -> DungeonGenerationSteps {
         let mut visitor = VecDungeonGenerationVisitor::default();
-        let (_grid, layout) = self.build(width, height);
+        let (grid, layout, offset) = self.build(width, height);
+
+        // Map a layout-space rectangle into the trimmed grid's coordinate space.
+        let rebase = |r: &GridRect| {
+            GridRect::new(
+                GridCoord2D::new(r.origin.x - offset.x, r.origin.y - offset.y),
+                r.width,
+                r.height,
+            )
+        };
 
         for (i, room) in layout.rooms.iter().enumerate() {
-            visitor.on_step(&DungeonGenerationStep::PlaceRoom { rect: *room });
+            visitor.on_step(&DungeonGenerationStep::PlaceRoom { rect: rebase(room) });
             if i < layout.corridors.len() {
                 visitor.on_step(&DungeonGenerationStep::PlaceCorridor {
-                    rect: layout.corridors[i],
+                    rect: rebase(&layout.corridors[i]),
                 });
             }
         }
-        if let Some(last) = layout.rooms.last() {
-            visitor.on_step(&DungeonGenerationStep::SetExit {
-                coord: last.center(),
-            });
+        if let Some(exit) = grid.exit() {
+            visitor.on_step(&DungeonGenerationStep::SetExit { coord: exit });
         }
         visitor.on_step(&DungeonGenerationStep::Complete);
 
@@ -188,7 +200,10 @@ impl RoomCorridorGenerator {
     }
 
     /// Run the placement algorithm and rasterize it into a trimmed grid.
-    fn build(&self, width: usize, height: usize) -> (DungeonGrid, Layout) {
+    ///
+    /// Returns the trimmed grid, the (untrimmed) layout, and the trim offset:
+    /// subtracting the offset from a layout coordinate maps it into the grid.
+    fn build(&self, width: usize, height: usize) -> (DungeonGrid, Layout, GridCoord2D) {
         let mut rng = StdRng::seed_from_u64(self.rng_seed);
 
         if width == 0 || height == 0 {
@@ -199,6 +214,7 @@ impl RoomCorridorGenerator {
                     corridors: Vec::new(),
                     dirs: Vec::new(),
                 },
+                GridCoord2D::new(0, 0),
             );
         }
 
@@ -217,8 +233,8 @@ impl RoomCorridorGenerator {
         }
 
         // Reuse the shared trim -> place_walls -> compute_edge_masks pipeline.
-        let grid = grid.trim(self.trim_padding);
-        (grid, layout)
+        let (grid, offset) = grid.trim_with_offset(self.trim_padding);
+        (grid, layout, offset)
     }
 
     /// Port of dungen-unity's `DungeonGenerator.asBoard`: place a first room,
@@ -233,8 +249,8 @@ impl RoomCorridorGenerator {
 
         // First room: placed at a random in-bounds position.
         let (rw, rh) = self.sample_room_size(rng, width, height);
-        let ox = rng.random_range(0..(width - rw + 1));
-        let oy = rng.random_range(0..(height - rh + 1));
+        let ox = rng.random_range(0..=(width - rw));
+        let oy = rng.random_range(0..=(height - rh));
         rooms.push(GridRect::new(GridCoord2D::new(ox, oy), rw, rh));
 
         let cardinals = Direction4::CARDINALS; // [N, E, S, W]
@@ -428,7 +444,7 @@ impl RoomCorridorGenerator {
 
 /// Sample an inclusive range `[min, max]`.
 fn sample(rng: &mut StdRng, min: usize, max: usize) -> usize {
-    rng.random_range(min..max + 1)
+    rng.random_range(min..=max)
 }
 
 /// Pick a corridor origin so a `thickness`-wide corridor lies within the room
@@ -439,7 +455,7 @@ fn pick_in_room(rng: &mut StdRng, lo: usize, hi: usize, thickness: usize) -> Opt
     if max_origin < lo {
         return None;
     }
-    Some(rng.random_range(lo..max_origin + 1))
+    Some(rng.random_range(lo..=max_origin))
 }
 
 /// Pick a room origin so a `room_len`-long side fully covers the span `[lo, hi]`
@@ -457,7 +473,7 @@ fn cover_span(
     if min_origin > max_origin {
         return None;
     }
-    Some(rng.random_range(min_origin..max_origin + 1))
+    Some(rng.random_range(min_origin..=max_origin))
 }
 
 /// Build the room connectivity graph from a placement layout.
@@ -541,6 +557,31 @@ mod tests {
         let f2: std::collections::HashSet<_> = g2.floor_iter().collect();
         assert_eq!(f1, f2);
         assert_eq!(g1.exit(), g2.exit());
+    }
+
+    #[test]
+    fn steps_are_in_trimmed_grid_space() {
+        // Step rects/exit must fall inside the bounds of the grid generate()
+        // returns, even with non-zero trim padding.
+        let generator = RoomCorridorGenerator::new_from_seed(42).with_trim_padding(2);
+        let grid = generator.generate(60, 60);
+        let (w, h) = (grid.width(), grid.height());
+
+        for step in generator.generate_steps(60, 60) {
+            match step {
+                DungeonGenerationStep::PlaceRoom { rect }
+                | DungeonGenerationStep::PlaceCorridor { rect } => {
+                    assert!(
+                        rect.right() < w && rect.bottom() < h,
+                        "step rect {rect:?} outside trimmed grid {w}x{h}"
+                    );
+                }
+                DungeonGenerationStep::SetExit { coord } => {
+                    assert!(coord.x < w && coord.y < h, "exit {coord:?} outside grid");
+                }
+                _ => {}
+            }
+        }
     }
 
     #[test]

--- a/amaze/src/grid_rect.rs
+++ b/amaze/src/grid_rect.rs
@@ -1,0 +1,211 @@
+use crate::grid_coord_2d::{GetCoordinateBounds2D, GridCoord2D};
+
+/// An axis-aligned rectangle on a 2D grid, addressed by its top-left origin.
+///
+/// Coordinates are inclusive: a rectangle with `origin = (2, 3)`, `width = 4`,
+/// `height = 2` covers `x in 2..=5` and `y in 3..=4`. Both dimensions are
+/// expected to be at least `1`.
+///
+/// `GridRect` is the shared building block for placement-based generation
+/// (rooms, corridors) and any other code that needs to reason about rectangular
+/// regions of a grid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GridRect {
+    /// Top-left corner of the rectangle.
+    pub origin: GridCoord2D,
+    /// Width in cells (at least 1).
+    pub width: usize,
+    /// Height in cells (at least 1).
+    pub height: usize,
+}
+
+impl GridRect {
+    /// Create a new rectangle from its top-left origin and dimensions.
+    #[inline]
+    pub fn new(origin: GridCoord2D, width: usize, height: usize) -> Self {
+        Self {
+            origin,
+            width,
+            height,
+        }
+    }
+
+    /// The smallest x coordinate covered by this rectangle.
+    #[inline]
+    pub fn left(&self) -> usize {
+        self.origin.x
+    }
+
+    /// The smallest y coordinate covered by this rectangle.
+    #[inline]
+    pub fn top(&self) -> usize {
+        self.origin.y
+    }
+
+    /// The largest x coordinate covered by this rectangle (inclusive).
+    #[inline]
+    pub fn right(&self) -> usize {
+        self.origin.x + self.width - 1
+    }
+
+    /// The largest y coordinate covered by this rectangle (inclusive).
+    #[inline]
+    pub fn bottom(&self) -> usize {
+        self.origin.y + self.height - 1
+    }
+
+    /// The top-left corner.
+    #[inline]
+    pub fn top_left(&self) -> GridCoord2D {
+        self.origin
+    }
+
+    /// The bottom-right corner (inclusive).
+    #[inline]
+    pub fn bottom_right(&self) -> GridCoord2D {
+        GridCoord2D::new(self.right(), self.bottom())
+    }
+
+    /// The (rounded-down) center cell of the rectangle.
+    #[inline]
+    pub fn center(&self) -> GridCoord2D {
+        GridCoord2D::new(
+            self.origin.x + self.width / 2,
+            self.origin.y + self.height / 2,
+        )
+    }
+
+    /// Returns true if the coordinate lies inside this rectangle.
+    #[inline]
+    pub fn contains(&self, coord: GridCoord2D) -> bool {
+        coord.x >= self.left()
+            && coord.x <= self.right()
+            && coord.y >= self.top()
+            && coord.y <= self.bottom()
+    }
+
+    /// Returns true if this rectangle fits entirely within the given bounds
+    /// (i.e. `origin` is non-negative — always true for `usize` — and the
+    /// far corner stays inside `width`/`height`).
+    #[inline]
+    pub fn fits_within(&self, bounds: &impl GetCoordinateBounds2D) -> bool {
+        self.right() < bounds.width() && self.bottom() < bounds.height()
+    }
+
+    /// Returns true if the two rectangles share at least one cell.
+    ///
+    /// Touching edges or corners do **not** count as intersecting — use
+    /// [`GridRect::collides`] for the stricter test that also rejects adjacency.
+    #[inline]
+    pub fn intersects(&self, other: &GridRect) -> bool {
+        self.left() <= other.right()
+            && other.left() <= self.right()
+            && self.top() <= other.bottom()
+            && other.top() <= self.bottom()
+    }
+
+    /// Returns true if the two rectangles overlap **or** touch (share an edge or
+    /// corner with no gap between them).
+    ///
+    /// This is the test used during placement: leaving at least a one-cell gap
+    /// between unrelated rooms guarantees a wall can be carved between them, so
+    /// they never visually merge.
+    #[inline]
+    pub fn collides(&self, other: &GridRect) -> bool {
+        // Separated by a gap of >= 1 cell in any direction => no collision.
+        let gap = self.right() + 1 < other.left()
+            || other.right() + 1 < self.left()
+            || self.bottom() + 1 < other.top()
+            || other.bottom() + 1 < self.top();
+        !gap
+    }
+
+    /// Iterate over every cell covered by this rectangle, row by row.
+    pub fn coords(&self) -> impl Iterator<Item = GridCoord2D> + '_ {
+        let (left, top, right, bottom) = (self.left(), self.top(), self.right(), self.bottom());
+        (top..=bottom).flat_map(move |y| (left..=right).map(move |x| GridCoord2D::new(x, y)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rect(x: usize, y: usize, w: usize, h: usize) -> GridRect {
+        GridRect::new(GridCoord2D::new(x, y), w, h)
+    }
+
+    #[test]
+    fn corners_and_center() {
+        let r = rect(2, 3, 4, 2);
+        assert_eq!(r.left(), 2);
+        assert_eq!(r.top(), 3);
+        assert_eq!(r.right(), 5);
+        assert_eq!(r.bottom(), 4);
+        assert_eq!(r.top_left(), GridCoord2D::new(2, 3));
+        assert_eq!(r.bottom_right(), GridCoord2D::new(5, 4));
+        assert_eq!(r.center(), GridCoord2D::new(4, 4));
+    }
+
+    #[test]
+    fn contains_only_interior() {
+        let r = rect(1, 1, 3, 3); // covers x,y in 1..=3
+        assert!(r.contains(GridCoord2D::new(1, 1)));
+        assert!(r.contains(GridCoord2D::new(3, 3)));
+        assert!(!r.contains(GridCoord2D::new(0, 1)));
+        assert!(!r.contains(GridCoord2D::new(4, 3)));
+    }
+
+    #[test]
+    fn intersects_overlap_touch_disjoint() {
+        let a = rect(0, 0, 3, 3); // x,y in 0..=2
+        // Overlapping
+        assert!(a.intersects(&rect(2, 2, 3, 3)));
+        // Touching edge (a.right = 2, other.left = 3): not an intersection
+        assert!(!a.intersects(&rect(3, 0, 2, 3)));
+        // Disjoint
+        assert!(!a.intersects(&rect(5, 5, 2, 2)));
+    }
+
+    #[test]
+    fn collides_treats_touching_as_collision() {
+        let a = rect(0, 0, 3, 3); // x,y in 0..=2
+        // Overlapping
+        assert!(a.collides(&rect(2, 2, 3, 3)));
+        // Edge-adjacent (gap 0)
+        assert!(a.collides(&rect(3, 0, 2, 3)));
+        // Corner-adjacent (gap 0)
+        assert!(a.collides(&rect(3, 3, 2, 2)));
+        // Separated by a one-cell gap
+        assert!(!a.collides(&rect(4, 0, 2, 3)));
+    }
+
+    #[test]
+    fn fits_within_bounds() {
+        struct Bounds(usize, usize);
+        impl GetCoordinateBounds2D for Bounds {
+            fn width(&self) -> usize {
+                self.0
+            }
+            fn height(&self) -> usize {
+                self.1
+            }
+        }
+        let bounds = Bounds(10, 10);
+        assert!(rect(0, 0, 10, 10).fits_within(&bounds));
+        assert!(!rect(0, 0, 11, 5).fits_within(&bounds));
+        assert!(!rect(8, 8, 3, 3).fits_within(&bounds));
+    }
+
+    #[test]
+    fn coords_visits_every_cell() {
+        let r = rect(1, 1, 2, 3); // 2 wide, 3 tall = 6 cells
+        let cells: Vec<_> = r.coords().collect();
+        assert_eq!(cells.len(), 6);
+        assert_eq!(cells[0], GridCoord2D::new(1, 1));
+        assert_eq!(cells[5], GridCoord2D::new(2, 3));
+        // Every cell is contained by the rect
+        assert!(cells.iter().all(|&c| r.contains(c)));
+    }
+}

--- a/amaze/src/grid_rect.rs
+++ b/amaze/src/grid_rect.rs
@@ -22,8 +22,17 @@ pub struct GridRect {
 
 impl GridRect {
     /// Create a new rectangle from its top-left origin and dimensions.
+    ///
+    /// # Panics
+    /// Panics if `width` or `height` is `0`. A zero-sized rectangle has no
+    /// valid `right`/`bottom` edge and would underflow the inclusive-bounds
+    /// arithmetic the rest of the type relies on.
     #[inline]
     pub fn new(origin: GridCoord2D, width: usize, height: usize) -> Self {
+        assert!(
+            width > 0 && height > 0,
+            "GridRect dimensions must be non-zero (got {width}x{height})"
+        );
         Self {
             origin,
             width,
@@ -67,12 +76,13 @@ impl GridRect {
         GridCoord2D::new(self.right(), self.bottom())
     }
 
-    /// The (rounded-down) center cell of the rectangle.
+    /// The center cell of the rectangle, rounding down for even dimensions
+    /// (i.e. the floor of the midpoint between the left/right and top/bottom edges).
     #[inline]
     pub fn center(&self) -> GridCoord2D {
         GridCoord2D::new(
-            self.origin.x + self.width / 2,
-            self.origin.y + self.height / 2,
+            (self.left() + self.right()) / 2,
+            (self.top() + self.bottom()) / 2,
         )
     }
 
@@ -145,7 +155,16 @@ mod tests {
         assert_eq!(r.bottom(), 4);
         assert_eq!(r.top_left(), GridCoord2D::new(2, 3));
         assert_eq!(r.bottom_right(), GridCoord2D::new(5, 4));
-        assert_eq!(r.center(), GridCoord2D::new(4, 4));
+        // Floor of the midpoint: x=(2+5)/2=3, y=(3+4)/2=3.
+        assert_eq!(r.center(), GridCoord2D::new(3, 3));
+        // Odd dimensions land on the true middle cell.
+        assert_eq!(rect(0, 0, 3, 3).center(), GridCoord2D::new(1, 1));
+    }
+
+    #[test]
+    #[should_panic(expected = "non-zero")]
+    fn new_rejects_zero_dimensions() {
+        let _ = rect(0, 0, 0, 4);
     }
 
     #[test]

--- a/amaze/src/lib.rs
+++ b/amaze/src/lib.rs
@@ -82,6 +82,7 @@ pub mod direction6;
 pub mod dungeon;
 pub mod generators;
 mod grid_coord_2d;
+pub mod grid_rect;
 mod hex_coord;
 pub mod path;
 #[cfg(feature = "representations")]
@@ -109,6 +110,7 @@ pub mod preamble {
     pub use crate::direction6::{Direction6, Direction6Iterator};
     pub use crate::dungeon::{DungeonGrid, DungeonType, TileType};
     pub use crate::grid_coord_2d::{GetCoordinateBounds2D, GridCoord2D, LinearizeCoords2D};
+    pub use crate::grid_rect::GridRect;
     pub use crate::hex_coord::HexCoord;
     pub use crate::path::Path;
     #[cfg(feature = "representations")]

--- a/amaze/tests/dungeon_tests.rs
+++ b/amaze/tests/dungeon_tests.rs
@@ -2,7 +2,10 @@
 
 #![cfg(all(feature = "representations", feature = "solvers"))]
 
-use amaze::dungeon::{DungeonType, DungeonWalkGenerator, solve_astar, solve_bfs};
+use amaze::direction4::Direction4;
+use amaze::dungeon::{
+    DungeonType, DungeonWalkGenerator, RoomCorridorGenerator, solve_astar, solve_bfs,
+};
 use amaze::preamble::*;
 use std::collections::{HashSet, VecDeque};
 
@@ -71,6 +74,82 @@ fn test_winding_connectivity() {
 
     assert_fully_connected(&dungeon);
     assert!(dungeon.exit().is_some());
+}
+
+#[test]
+fn test_chambers_connectivity() {
+    let generator = RoomCorridorGenerator::new_from_seed(42);
+    let dungeon = generator.generate(60, 60);
+
+    // Every room must be reachable from the entrance through its corridors.
+    assert_fully_connected(&dungeon);
+    assert!(dungeon.exit().is_some());
+}
+
+#[test]
+fn test_chambers_bfs_finds_path_to_exit() {
+    let generator = RoomCorridorGenerator::new_from_seed(7);
+    let dungeon = generator.generate(60, 60);
+
+    let passability = PassabilityGrid::from(&dungeon);
+    let (ex, ey) = passability.entrance_position();
+    let (xx, xy) = passability.exit_position();
+
+    let path = solve_bfs(
+        &passability,
+        GridCoord2D::new(ex, ey),
+        GridCoord2D::new(xx, xy),
+    );
+    assert!(
+        path.is_some(),
+        "BFS should reach the exit in a chambers dungeon"
+    );
+}
+
+#[test]
+fn test_chambers_graph_matches_doors() {
+    let generator = RoomCorridorGenerator::new_from_seed(123).with_room_count_range(5, 5);
+    let (_dungeon, graph) = generator.generate_with_graph(80, 80);
+
+    assert!(!graph.is_empty(), "chambers graph should contain rooms");
+
+    // Every linked neighbour is reciprocated in the opposite direction, and
+    // every non-isolated room exposes at least one door.
+    for room in graph.iter() {
+        let mut has_door = false;
+        for dir in [
+            Direction4::NORTH,
+            Direction4::SOUTH,
+            Direction4::EAST,
+            Direction4::WEST,
+        ] {
+            if let Some(neighbor) = room.get_neighbor(dir) {
+                has_door = true;
+                assert_eq!(
+                    graph[neighbor].get_neighbor(dir.opposite()),
+                    Some(room.index()),
+                    "neighbour link not reciprocated"
+                );
+            }
+        }
+        // A connected chain of >1 rooms leaves no isolated nodes.
+        assert!(
+            has_door || graph.len() == 1,
+            "room {:?} is isolated",
+            room.index()
+        );
+    }
+}
+
+#[test]
+fn test_chambers_same_seed_is_deterministic() {
+    let d1 = RoomCorridorGenerator::new_from_seed(999).generate(60, 60);
+    let d2 = RoomCorridorGenerator::new_from_seed(999).generate(60, 60);
+
+    let floors1: HashSet<_> = d1.floor_iter().collect();
+    let floors2: HashSet<_> = d2.floor_iter().collect();
+    assert_eq!(floors1, floors2);
+    assert_eq!(d1.exit(), d2.exit());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds a fourth dungeon style, **Chambers**: discrete, non-overlapping rooms joined by explicit corridors. Where the existing walk-based generator carves space by walking and stamping rooms that merge into their neighbours, this one *places* rectangular rooms with collision detection and backtracking, so every room stays a distinct chamber reached through a corridor.

It is also the first dungeon generator to expose a room connectivity graph alongside the tile grid, finally wiring the previously-unused `Room4List` into dungeon generation.

## Why

`amaze` could only produce organic, merge-y dungeons (Caverns/Rooms/Winding). The room-and-corridor approach from [dungen-unity](https://github.com/fdefelici/dungen-unity) fills the gap — clean separated rooms with real corridors — and its cardinal connections map directly onto the `Room4`/`Direction4` graph the crate already shipped but never populated for dungeons. The port is expressed in the crate's own idioms rather than transliterated from the C# class hierarchy.

## Key changes

- **`GridRect`** — a reusable axis-aligned grid rectangle primitive (overlap/touch tests, containment, cell iteration), replacing dungen's Cell/Grid/IShape/Room/Corridor hierarchy with one type.
- **`RoomCorridorGenerator`** — placement algorithm with clockwise direction retry and corridor backtracking; reuses the existing `DungeonGenerator` trait, the `DungeonGrid` trim → place_walls → edge_masks pipeline, and the visitor/step animation infra.
- **`generate_with_graph`** — returns the tile grid plus a `Room4List` whose N/S/E/W links follow the corridors; the room tag is coordinate-free so it cannot desync from the trimmed grid.
- **`DungeonType::Chambers`** — new selectable type; the walk generator falls back to Rooms-style stamping if it ever receives it.
- **CLI/GUI** — `--type chambers` and a Chambers combo entry.
- **Taskfile** — deduped the repeated cargo precondition into a YAML anchor, broadened lint/test to the whole workspace, and added `default`/`check`/`ci`/`clean`/`fmt:check` plus a `run:dungeon` example.

## Notes

No behavioural change to the existing generators. Chambers ignores the `floor_count` argument of the shared `generate` signature — room count is driven by `with_room_count_range` instead — which is documented on the method.

## Review guide

Start with `amaze/src/grid_rect.rs` to understand the rectangle primitive and the `intersects` vs `collides` distinction (touching counts as a collision, which is what guarantees a wall gap between unrelated rooms). Then read `RoomCorridorGenerator::build_layout` in `amaze/src/dungeon/room_corridor.rs` — that's the load-bearing placement loop; check the corridor/room fit geometry in `try_corridor`/`try_room` and the connection invariant (corridor mouth ⊆ source room, destination room ⊇ corridor mouth). `build_graph` is where the `Room4List` links are derived from corridor directions. The integration tests in `amaze/tests/dungeon_tests.rs` cover connectivity, BFS-to-exit, determinism, and reciprocal graph links.